### PR TITLE
[ESN-1401] Add queryStringToJSON.js and fix filters for embeds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Development Installation
 To install ckanext-charts for development, activate your CKAN virtualenv and
 do::
 
-    git clone https://github.com/keitaroinc/ckanext-c3charts.git
+    git clone https://github.com/OpenGov-OpenData/ckanext-c3charts.git
     cd ckanext-c3charts
     python setup.py develop
     pip install -r dev-requirements.txt

--- a/ckanext/c3charts/fanstatic/charts_view.js
+++ b/ckanext/c3charts/fanstatic/charts_view.js
@@ -11,7 +11,10 @@ ckan.module('c3charts_builder', function ($, _) {
     }
 
     function setupFilters(defaultFilters) {
-        var routeFilters = ckan.views.filters.get();
+        var routeFilters = {};
+        if (window.parent.ckan.views && window.parent.ckan.views.filters) {
+            routeFilters = window.parent.ckan.views.filters.get();
+        }
 
         return $.extend({}, defaultFilters, routeFilters);
     }

--- a/ckanext/c3charts/fanstatic/charts_view.js
+++ b/ckanext/c3charts/fanstatic/charts_view.js
@@ -12,9 +12,11 @@ ckan.module('c3charts_builder', function ($, _) {
 
     function setupFilters(defaultFilters) {
         var routeFilters = {};
-        if (window.parent.ckan.views && window.parent.ckan.views.filters) {
-            routeFilters = window.parent.ckan.views.filters.get();
-        }
+        try {
+            if (window.parent.ckan.views && window.parent.ckan.views.filters) {
+                routeFilters = window.parent.ckan.views.filters.get();
+            }
+        } catch(e) {}
 
         return $.extend({}, defaultFilters, routeFilters);
     }

--- a/ckanext/c3charts/fanstatic/resource.config
+++ b/ckanext/c3charts/fanstatic/resource.config
@@ -8,6 +8,7 @@ main =
     vendor/d3.js
     vendor/c3.css
     vendor/c3.js
+    vendor/queryStringToJSON.js
     vendor/backend.ckan.js
     charts.css
     charts.js

--- a/ckanext/c3charts/fanstatic/vendor/queryStringToJSON.js
+++ b/ckanext/c3charts/fanstatic/vendor/queryStringToJSON.js
@@ -1,0 +1,91 @@
+/**
+ * Return a new JSON object of the old string.
+ * Turns:
+ *      file.js?a=1&amp;b.c=3.0&b.d=four&a_false_value=false&a_null_value=null
+ * Into:
+ *      {"a":1,"b":{"c":3,"d":"four"},"a_false_value":false,"a_null_value":null}
+ * @version 1.1.0
+ * @date July 16, 2010
+ * @since 1.0.0, June 30, 2010
+ * @package jquery-sparkle {@link http://balupton.com/projects/jquery-sparkle}
+ * @author Benjamin "balupton" Lupton {@link http://balupton.com}
+ * @copyright (c) 2009-2010 Benjamin Arthur Lupton {@link http://balupton.com}
+ * @license MIT License {@link http://creativecommons.org/licenses/MIT/}
+ */
+String.prototype.queryStringToJSON = String.prototype.queryStringToJSON || function ( )
+{   // Turns a params string or url into an array of params
+    // Prepare
+    var params = String(this);
+    // Remove url if need be
+    params = params.substring(params.indexOf('?')+1);
+    // params = params.substring(params.indexOf('#')+1);
+    // Change + to %20, the %20 is fixed up later with the decode
+    params = params.replace(/\+/g, '%20');
+    // Do we have JSON string
+    if ( params.substring(0,1) === '{' && params.substring(params.length-1) === '}' )
+    {   // We have a JSON string
+        return eval(decodeURIComponent(params));
+    }
+    // We have a params string
+    params = params.split(/\&(amp\;)?/);
+    var json = {};
+    // We have params
+    for ( var i = 0, n = params.length; i < n; ++i )
+    {
+        // Adjust
+        var param = params[i] || null;
+        if ( param === null ) { continue; }
+        param = param.split('=');
+        if ( param === null ) { continue; }
+        // ^ We now have "var=blah" into ["var","blah"]
+
+        // Get
+        var key = param[0] || null;
+        if ( key === null ) { continue; }
+        if ( typeof param[1] === 'undefined' ) { continue; }
+        var value = param[1];
+        // ^ We now have the parts
+
+        // Fix
+        key = decodeURIComponent(key);
+        value = decodeURIComponent(value);
+        try {
+            // value can be converted
+            value = eval(value);
+        } catch ( e ) {
+            // value is a normal string
+        }
+
+        // Set
+        // window.console.log({'key':key,'value':value}, split);
+        var keys = key.split('.');
+        if ( keys.length === 1 )
+        {   // Simple
+            json[key] = value;
+        }
+        else
+        {   // Advanced (Recreating an object)
+            var path = '',
+                cmd = '';
+            // Ensure Path Exists
+            $.each(keys,function(ii,key){
+                path += '["'+key.replace(/"/g,'\\"')+'"]';
+                jsonCLOSUREGLOBAL = json; // we have made this a global as closure compiler struggles with evals
+                cmd = 'if ( typeof jsonCLOSUREGLOBAL'+path+' === "undefined" ) jsonCLOSUREGLOBAL'+path+' = {}';
+                eval(cmd);
+                json = jsonCLOSUREGLOBAL;
+                delete jsonCLOSUREGLOBAL;
+            });
+            // Apply Value
+            jsonCLOSUREGLOBAL = json; // we have made this a global as closure compiler struggles with evals
+            valueCLOSUREGLOBAL = value; // we have made this a global as closure compiler struggles with evals
+            cmd = 'jsonCLOSUREGLOBAL'+path+' = valueCLOSUREGLOBAL';
+            eval(cmd);
+            json = jsonCLOSUREGLOBAL;
+            delete jsonCLOSUREGLOBAL;
+            delete valueCLOSUREGLOBAL;
+        }
+        // ^ We now have the parts added to your JSON object
+    }
+    return json;
+};


### PR DESCRIPTION
## [TICKET](https://opengovinc.atlassian.net/browse/ESN-1401)

## Description
<!--- Describe these changes in detail --->
This PR fixes a bug when trying to embed a c3 chart.

The issue is caused by a missing JS file, `queryStringToJSON.js`. This file is in the [ckanext-basiccharts](https://github.com/ckan/ckanext-basiccharts/blob/master/ckanext/basiccharts/theme/public/vendor/queryStringToJSON.js) extension, but is not available to a c3 chart embed. To fix this issue we add the `queryStringToJSON.js` file to the c3 charts extension.

We'll also add a try/catch and an if statement for url filters from `window.parent.ckan.views.filters`. An embedded c3 chart view in a different domain will not have access to the `window.parent.ckan` property. We add a try/catch to suppress the error and allow the view to load. This means that external embedded views can't use url filters, which is acceptable.

Related to https://github.com/ckan/ckan/pull/2423.

## Test Procedure
<!--- List the steps involved to test the changes --->
- Install the extension
```
. /usr/lib/ckan/default/in/activate
cd /usr/lib/ckan/default/src/
git clone https://github.com/OpenGov-OpenData/ckanext-c3charts.git
cd ckanext-c3charts
python setup.py develop
```
- Add the plugin to the ckan ini config file and restart ckan
```
ckan.plugins = ... c3charts ...
```
- Create a c3 chart view for a resource with data in the datastore.
- Go to the c3 chart view and click on the embed button and get the url in the iframe snippet.
- Visit the embed url in a new browser tab and confirm that the page is blank and that there is an issue.
- Checkout this PR and restart ckan.
- Refresh the embed url in the browser and confirm that the c3 chart is now displayed.